### PR TITLE
When matching black holes prefer those which survive at later snapshots

### DIFF
--- a/bin/lightcone_io_match_black_holes.py
+++ b/bin/lightcone_io_match_black_holes.py
@@ -235,8 +235,8 @@ def match_black_holes(args):
     # assume exactly the same definitions of Mpc, Msolar etc that SWIFT used.
     if comm_rank == 0:
         physical_constants_cgs = {}
-        snapshot_units = {}
-        filename = args.snapshot_format.format(snap_nr=final_snap, file_nr=0)
+        snapshot_units = {}        
+        filename = (args.snapshot_format % {"snap_nr" : final_snap}) + ".0.hdf5"
         with h5py.File(filename, "r") as infile:
             group = infile["PhysicalConstants/CGS"]
             for name in group.attrs:
@@ -324,12 +324,12 @@ def match_black_holes(args):
         # Choose the tracer BH particle to use for each object.
         # Returns ID and position of the selected BH particle.
         tracer_id, tracer_pos = choose_bh_tracer(merger_tree["Subhalo/ID"][i1:i2],
-                                                 snap_nr, final_snap, args.snapshot_format,
+                                                 snap_nr[redshift_nr], final_snap, args.snapshot_format,
                                                  args.membership_format, membership_cache)
 
         # Store selected tracer particle position and ID
         merger_tree["Subhalo/ID_tracer_bh"][i1:i2] = tracer_id
-        for i, axis in enumerate("X","Y","Z"):
+        for i, axis in enumerate(("X","Y","Z")):
             merger_tree[f"Subhalo/{axis}tracer_bh"][i1:i2] = tracer_pos[:,i]
 
         # Each snapshot populates a redshift range which reaches half way to adjacent snapshots

--- a/bin/lightcone_io_match_black_holes.py
+++ b/bin/lightcone_io_match_black_holes.py
@@ -339,7 +339,9 @@ def match_black_holes(args):
         z = merger_tree["Subhalo/Redshift"][first_at_redshift[redshift_nr]:first_at_next_redshift[redshift_nr]]
         if not(np.all(z==redshifts[redshift_nr])):
             raise RuntimeError("Redshift ranges not identified correctly!")
-        snap_nr[redshift_nr] = merger_tree["Subhalo/SnapNum"][first_at_redshift[redshift_nr]]
+        if nr_at_redshift[redshift_nr] > 0:
+            snap_nr[redshift_nr] = merger_tree["Subhalo/SnapNum"][first_at_redshift[redshift_nr]]
+    comm.Allreduce(MPI.IN_PLACE, snap_nr, op=MPI.MAX) # Replace -1s where rank has no halos at snapshot
     assert np.all(snap_nr >= 0)
     message("Identified range of halos at each redshift")
 

--- a/bin/lightcone_io_particle_halo_ids.py
+++ b/bin/lightcone_io_particle_halo_ids.py
@@ -337,24 +337,14 @@ def compute_particle_group_index(halo_id, halo_pos, halo_radius, part_pos):
 if __name__ == "__main__":
 
     # Get command line arguments
-    if comm.Get_rank() == 0:
-        os.environ['COLUMNS'] = '80' # Can't detect terminal width when running under MPI?
-        parser = ThrowingArgumentParser(description='Create lightcone halo catalogues.')
-        parser.add_argument('lightcone_dir',  help='Directory with lightcone particle outputs')
-        parser.add_argument('lightcone_base', help='Base name of the lightcone to use')
-        parser.add_argument('halo_lightcone_filenames', help='Format string to generate halo lightcone filenames')
-        parser.add_argument('soap_filenames', help='Format string to generate SOAP filenames')
-        parser.add_argument('output_dir',     help='Where to write the output')
-        try:
-            args = parser.parse_args()
-        except ArgumentParserError as e:
-            args = None
-    else:
-        args = None
-    args = comm.bcast(args)
-    if args is None:
-        MPI.Finalize()
-        sys.exit(0)
+    from virgo.mpi.util import MPIArgumentParser
+    parser = MPIArgumentParser(description='Create lightcone halo catalogues.')
+    parser.add_argument('lightcone_dir',  help='Directory with lightcone particle outputs')
+    parser.add_argument('lightcone_base', help='Base name of the lightcone to use')
+    parser.add_argument('halo_lightcone_filenames', help='Format string to generate halo lightcone filenames')
+    parser.add_argument('soap_filenames', help='Format string to generate SOAP filenames')
+    parser.add_argument('output_dir',     help='Where to write the output')
+    args = parser.parse_args()
 
     message(f"Starting on {comm_size} MPI ranks")
 
@@ -383,7 +373,7 @@ if __name__ == "__main__":
 
         # Read in positions of lightcone particles of this type
         message(f"Reading particles")
-        part_pos = mf.read(("Coordinates",), group=ptype)["Coordinates"]
+        part_pos = mf.read("Coordinates", group=ptype)
 
         # Record number of particles read from each file
         elements_per_file = mf.get_elements_per_file("Coordinates", group=ptype)

--- a/scripts/FLAMINGO/combine_L1000N0900.sh
+++ b/scripts/FLAMINGO/combine_L1000N0900.sh
@@ -19,7 +19,6 @@ input_dir=/cosma8/data/dp004/flamingo/Runs/${sim}/lightcones/
 output_dir=/cosma8/data/dp004/jch/FLAMINGO/ScienceRuns/${sim}/combined_maps/
 
 # Output is a single large file per map, so stripe
-\rm -rf ${output_dir}
 \mkdir -p ${output_dir}
 lfs setstripe --stripe-count=-1 --stripe-size=32M ${output_dir}
 

--- a/scripts/FLAMINGO/combine_L1000N1800.sh
+++ b/scripts/FLAMINGO/combine_L1000N1800.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 #
 #SBATCH --nodes=1
-#SBATCH --tasks-per-node=70
 #SBATCH --cpus-per-task=1
 #SBATCH -o ./logs/L1000N1800/combine_maps_%x.%a.out
 #SBATCH -p cosma8
 #SBATCH -A dp004
-#SBATCH -t 72:00:00
+#SBATCH -t 48:00:00
 #
 
 module purge

--- a/scripts/FLAMINGO/combine_L1000N1800.sh
+++ b/scripts/FLAMINGO/combine_L1000N1800.sh
@@ -20,7 +20,6 @@ input_dir=/cosma8/data/dp004/flamingo/Runs/${sim}/lightcones/
 output_dir=/cosma8/data/dp004/jch/FLAMINGO/ScienceRuns/${sim}/combined_maps/
 
 # Output is a single large file per map, so stripe
-\rm -rf ${output_dir}
 \mkdir -p ${output_dir}
 lfs setstripe --stripe-count=-1 --stripe-size=32M ${output_dir}
 

--- a/scripts/FLAMINGO/correct_L1000N1800.sh
+++ b/scripts/FLAMINGO/correct_L1000N1800.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 #
 #SBATCH --nodes=1
-#SBATCH --tasks-per-node=128
 #SBATCH --cpus-per-task=1
 #SBATCH -o ./logs/L1000N1800/correct_%x.lightcone%a.out
 #SBATCH -p cosma8
 #SBATCH -A dp004
-#SBATCH -t 72:00:00
+#SBATCH -t 48:00:00
 #
 
 module purge

--- a/scripts/FLAMINGO/downsample_L1000N0900.sh
+++ b/scripts/FLAMINGO/downsample_L1000N0900.sh
@@ -23,7 +23,6 @@ input_dir=/cosma8/data/dp004/jch/FLAMINGO/ScienceRuns/${sim}/neutrino_corrected_
 output_dir=/cosma8/data/dp004/jch/FLAMINGO/ScienceRuns/${sim}/neutrino_corrected_maps_downsampled_${new_nside}/
 
 # Output is a single large file per map, so stripe
-\rm -rf ${output_dir}
 \mkdir -p ${output_dir}
 lfs setstripe --stripe-count=-1 --stripe-size=32M ${output_dir}
 

--- a/scripts/FLAMINGO/downsample_L1000N1800.sh
+++ b/scripts/FLAMINGO/downsample_L1000N1800.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 #
 #SBATCH --nodes=1
-#SBATCH --tasks-per-node=10
 #SBATCH --cpus-per-task=1
 #SBATCH -o ./logs/L1000N1800/downsample4096_%x.lightcone%a.out
 #SBATCH -p cosma8
 #SBATCH -A dp004
-#SBATCH -t 72:00:00
+#SBATCH -t 48:00:00
 #
 
 new_nside=4096

--- a/scripts/FLAMINGO/downsample_L1000N1800.sh
+++ b/scripts/FLAMINGO/downsample_L1000N1800.sh
@@ -22,7 +22,6 @@ input_dir=/cosma8/data/dp004/jch/FLAMINGO/ScienceRuns/${sim}/neutrino_corrected_
 output_dir=/cosma8/data/dp004/jch/FLAMINGO/ScienceRuns/${sim}/neutrino_corrected_maps_downsampled_${new_nside}/
 
 # Output is a single large file per map, so stripe
-\rm -rf ${output_dir}
 \mkdir -p ${output_dir}
 lfs setstripe --stripe-count=-1 --stripe-size=32M ${output_dir}
 

--- a/scripts/FLAMINGO/downsample_L1000N3600.sh
+++ b/scripts/FLAMINGO/downsample_L1000N3600.sh
@@ -23,7 +23,6 @@ input_dir=/cosma8/data/dp004/jch/FLAMINGO/ScienceRuns/${sim}/neutrino_corrected_
 output_dir=/cosma8/data/dp004/jch/FLAMINGO/ScienceRuns/${sim}/neutrino_corrected_maps_downsampled_${new_nside}/
 
 # Output is a single large file per map, so stripe
-\rm -rf ${output_dir}
 \mkdir -p ${output_dir}
 lfs setstripe --stripe-count=-1 --stripe-size=32M ${output_dir}
 

--- a/scripts/FLAMINGO/submit_L1000N1800.sh
+++ b/scripts/FLAMINGO/submit_L1000N1800.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+if [ "$#" -ne 1 ] ; then
+  echo "Usage: ./submit_L1000N1800.sh run_name"
+  exit 1
+fi
+
+run_name="${1}"
+sim="L1000N1800/${run_name}"
+if [ ! -d /cosma8/data/dp004/flamingo/Runs/${sim} ] ; then
+  echo No directory found for run ${sim}
+  exit 1
+fi
+
+# Submit job to combine maps
+combine_job_id=`sbatch --parsable -J "${run_name}" --array=0-1 ./combine_L1000N1800.sh`
+require_combined="--dependency=aftercorr:${combine_job_id}"
+
+# Submit job to correct combined maps
+correct_job_id=`sbatch --parsable -J "${run_name}" --array=0-1 ${require_combined} ./correct_L1000N1800.sh`
+require_corrected="--dependency=aftercorr:${correct_job_id}"
+
+# Submit job to downsample combined maps
+downsample_job_id=`sbatch --parsable -J "${run_name}" --array=0-1 ${require_corrected} ./downsample_L1000N1800.sh`


### PR DESCRIPTION
This is to avoid missing halos in the halo lightcone when the BH particle used as a tracer merges away.