### PR TITLE
Improvements to halo lightcone code

### DIFF
--- a/scripts/FLAMINGO/halo_ids_L1000N1800.sh
+++ b/scripts/FLAMINGO/halo_ids_L1000N1800.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 #
-#SBATCH --nodes=2
+#SBATCH --nodes=8
 #SBATCH --tasks-per-node=128
 #SBATCH --cpus-per-task=1
 #SBATCH -o ./logs/L1000N1800/halo_ids_%x.lightcone%a.out
 #SBATCH -p cosma8
 #SBATCH -A dp004
-#SBATCH -t 2:00:00
+#SBATCH -t 4:00:00
 #
 
 module purge
@@ -21,20 +21,20 @@ lightcone_dir="/cosma8/data/dp004/flamingo/Runs/${sim}/particle_lightcones/"
 lightcone_base="lightcone${lightcone_nr}"
 
 # Location of the halo lightcone
-halo_lightcone_filenames="/snap8/scratch/dp004/jch/FLAMINGO/ScienceRuns/L1000N1800/HYDRO_FIDUCIAL/lightcone_halos_shell_centres/${lightcone_base}/lightcone_halos_%(file_nr)04d.hdf5"
+halo_lightcone_filenames="/snap8/scratch/dp004/jch/FLAMINGO/ScienceRuns/L1000N1800/HYDRO_FIDUCIAL/lightcone_halos_bh_fix/${lightcone_base}/lightcone_halos_%(file_nr)04d.hdf5"
 
 # Location of SOAP catalogues
 soap_filenames="/cosma8/data/dp004/flamingo/Runs/L1000N1800/HYDRO_FIDUCIAL/SOAP/halo_properties_%(snap_nr)04d.hdf5"
 
 # Where to write the output
-output_dir="/snap8/scratch/dp004/jch/FLAMINGO/ScienceRuns/${sim}/lightcone_particle_halo_ids/lightcone${lightcone_nr}/"
-#\mkdir -p ${output_dir}
-#lfs setstripe --stripe-count=-1 --stripe-size=32M ${output_dir}
+output_dir="/snap8/scratch/dp004/jch/FLAMINGO/ScienceRuns/${sim}/lightcone_particle_halo_ids_bh_fix/lightcone${lightcone_nr}/"
+\mkdir -p ${output_dir}
+lfs setstripe --stripe-count=-1 --stripe-size=32M ${output_dir}
 
 # Assume we're running from scripts/FLAMINGO in the source directory
 script=../../bin/lightcone_io_particle_halo_ids.py 
 
-mpirun python3 -m mpi4py ${script} \
+mpirun --output-filename halo_ids python3 -m mpi4py ${script} \
     "${lightcone_dir}" "${lightcone_base}" \
     "${halo_lightcone_filenames}" \
     "${soap_filenames}" \

--- a/scripts/FLAMINGO/match_bh_L1000N1800.sh
+++ b/scripts/FLAMINGO/match_bh_L1000N1800.sh
@@ -6,7 +6,7 @@
 #SBATCH -o ./logs/L1000N1800/match_bh_%x.lightcone%a.out
 #SBATCH -p cosma8
 #SBATCH -A dp004
-#SBATCH -t 10:00:00
+#SBATCH -t 3:00:00
 #
 
 module purge
@@ -17,22 +17,35 @@ sim="L1000N1800/${SLURM_JOB_NAME}"
 lightcone_nr=${SLURM_ARRAY_TASK_ID}
 
 # Location of the merger trees
-tree_filename=/cosma8/data/dp004/jch/FLAMINGO/MergerTrees/ScienceRuns/${sim}/trees_f0.1_min10_max100/vr_trees.hdf5
+tree_filename=/cosma8/data/dp004/jch/FLAMINGO/MergerTrees/ScienceRuns/${sim}/trees_f0.1_min10_max100_vpeak/vr_trees.hdf5
 
 # Location of the lightcone particle data
 lightcone_dir=/cosma8/data/dp004/flamingo/Runs/${sim}/particle_lightcones/
 lightcone_base=lightcone${lightcone_nr}
 
-# Location of a snapshot to get metadata
-snapshot_file=/cosma8/data/dp004/flamingo/Runs/${sim}/snapshots/flamingo_0077/flamingo_0077.0.hdf5
+# Location of snapshot files
+snapshot_format="/cosma8/data/dp004/flamingo/Runs/${sim}/snapshots/flamingo_%(snap_nr)04d/flamingo_%(snap_nr)04d"
+
+# Determine name of halo membership directories
+if [ -e /cosma8/data/dp004/flamingo/Runs/${sim}/SOAP/membership_0077/membership_0077.0.hdf5 ] ; then
+  membership_dir=membership
+  membership_name=membership
+else
+  membership_dir=membership
+  membership_name=vr_membership
+fi
+
+# Location of halo membership files
+membership_format="/cosma8/data/dp004/flamingo/Runs/${sim}/SOAP/${membership_dir}_%(snap_nr)04d/${membership_name}_%(snap_nr)04d"
+echo Membership files are at ${membership_format}
 
 # Where to write the output
 #output_dir=/cosma8/data/dp004/jch/FLAMINGO/ScienceRuns/${sim}/lightcone_halos/lightcone${lightcone_nr}/
-output_dir=/snap8/scratch/dp004/jch/FLAMINGO/ScienceRuns/${sim}/lightcone_halos_shell_centres/lightcone${lightcone_nr}/
+output_dir=/snap8/scratch/dp004/jch/FLAMINGO/ScienceRuns/${sim}/lightcone_halos/lightcone${lightcone_nr}/
 \mkdir -p ${output_dir}
 lfs setstripe --stripe-count=-1 --stripe-size=32M ${output_dir}
 
 # Assume we're running from scripts/FLAMINGO in the source directory
 script=../../bin/lightcone_io_match_black_holes.py 
 
-mpirun python3 -m mpi4py ${script} ${tree_filename} ${lightcone_dir} ${lightcone_base} ${snapshot_file} ${output_dir}
+mpirun -tag-output python3 -m mpi4py ${script} ${tree_filename} ${lightcone_dir} ${lightcone_base} ${snapshot_format} ${membership_format} ${output_dir}


### PR DESCRIPTION
This modifies the halo lightcone code so that it prefers to use black hole particles which exist at the next snapshot as tracers of the halos. This reduces the chance of missing halos in the output because the tracer BH has ceased to exist.